### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tayoososanya0663/3bfbb62a-b552-4968-a0c2-dd0ac52f6ee2/3b7ce11e-ad84-4dca-a56c-eb2d091cf2d7/_apis/work/boardbadge/64bfddfc-8ef5-4271-9d44-cbc1e0b177d0)](https://dev.azure.com/tayoososanya0663/3bfbb62a-b552-4968-a0c2-dd0ac52f6ee2/_boards/board/t/3b7ce11e-ad84-4dca-a56c-eb2d091cf2d7/Microsoft.RequirementCategory)
 # sfXtra
 
 ## Summary


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tayoososanya0663/3bfbb62a-b552-4968-a0c2-dd0ac52f6ee2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.